### PR TITLE
refactor SearchIntegrationTestCase for easier usage

### DIFF
--- a/tests/Rollerworks/Component/Search/Tests/Exporter/SearchConditionExporterTestCase.php
+++ b/tests/Rollerworks/Component/Search/Tests/Exporter/SearchConditionExporterTestCase.php
@@ -63,12 +63,12 @@ abstract class SearchConditionExporterTestCase extends SearchIntegrationTestCase
      */
     protected function getFieldSet($build = true)
     {
-        $fieldSet = new FieldSetBuilder('test', $this->factory);
-        $fieldSet->add($this->factory->createField('id', 'integer')->setAcceptRange(true)->setAcceptCompares(true));
-        $fieldSet->add($this->factory->createField('name', 'text')->setAcceptPatternMatch(true));
-        $fieldSet->add($this->factory->createField('lastname', 'text'));
+        $fieldSet = new FieldSetBuilder('test', $this->getFactory());
+        $fieldSet->add($this->getFactory()->createField('id', 'integer')->setAcceptRange(true)->setAcceptCompares(true));
+        $fieldSet->add($this->getFactory()->createField('name', 'text')->setAcceptPatternMatch(true));
+        $fieldSet->add($this->getFactory()->createField('lastname', 'text'));
         $fieldSet->add(
-            $this->factory->createField('date', 'date', array('format' => 'MM-dd-yyyy'))
+            $this->getFactory()->createField('date', 'date', array('format' => 'MM-dd-yyyy'))
               ->setAcceptRange(true)
               ->setAcceptCompares(true)
         );

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -18,12 +18,12 @@ class BirthdayTypeTest extends FieldTypeTestCase
 {
     public function testCreate()
     {
-        $this->factory->createField('birthday', 'birthday');
+        $this->getFactory()->createField('birthday', 'birthday');
     }
 
     public function testDateOnlyInput()
     {
-        $field = $this->factory->createField('birthday', 'birthday', array(
+        $field = $this->getFactory()->createField('birthday', 'birthday', array(
             'format' => 'yyyy-MM-dd',
             'allow_age' => false,
         ));
@@ -35,7 +35,7 @@ class BirthdayTypeTest extends FieldTypeTestCase
 
     public function testAllowAgeInput()
     {
-        $field = $this->factory->createField('birthday', 'birthday', array(
+        $field = $this->getFactory()->createField('birthday', 'birthday', array(
             'format' => 'yyyy-MM-dd',
         ));
 
@@ -47,7 +47,7 @@ class BirthdayTypeTest extends FieldTypeTestCase
 
     public function testWrongInputFails()
     {
-        $field = $this->factory->createField('birthday', 'birthday', array(
+        $field = $this->getFactory()->createField('birthday', 'birthday', array(
             'allow_age' => true,
         ));
 

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -59,7 +59,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
      */
     public function testChoicesOptionExpectsArray()
     {
-        $this->factory->createField('choice', 'choice', array(
+        $this->getFactory()->createField('choice', 'choice', array(
             'choices' => new \ArrayObject(),
         ));
     }
@@ -69,26 +69,26 @@ class ChoiceTypeTest extends FieldTypeTestCase
      */
     public function testChoiceListOptionExpectsChoiceListInterface()
     {
-        $this->factory->createField('choice', 'choice', array(
+        $this->getFactory()->createField('choice', 'choice', array(
             'choice_list' => array('foo' => 'foo'),
         ));
     }
 
     public function testChoiceListAndChoicesCanBeEmpty()
     {
-        $this->factory->createField('choice', 'choice');
+        $this->getFactory()->createField('choice', 'choice');
     }
 
     public function testSubmitSingleNonExpandedInvalidChoice()
     {
-        $this->factory->createField('choice', 'choice', array(
+        $this->getFactory()->createField('choice', 'choice', array(
             'choices' => $this->choices,
         ));
     }
 
     public function testObjectChoices()
     {
-        $field = $this->factory->createField('choice', 'choice', array(
+        $field = $this->getFactory()->createField('choice', 'choice', array(
             'choice_list' => new ObjectChoiceList(
                 $this->objectChoices,
                 // label path
@@ -108,7 +108,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
 
     public function testObjectChoicesByLabel()
     {
-        $field = $this->factory->createField('choice', 'choice', array(
+        $field = $this->getFactory()->createField('choice', 'choice', array(
             'label_as_value' => true,
             'choice_list' => new ObjectChoiceList(
                 $this->objectChoices,
@@ -129,7 +129,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
 
     public function testArrayChoices()
     {
-        $field = $this->factory->createField('choice', 'choice', array(
+        $field = $this->getFactory()->createField('choice', 'choice', array(
             'choices' => $this->choices,
         ));
 
@@ -138,7 +138,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
 
     public function testNumericChoices()
     {
-        $field = $this->factory->createField('choice', 'choice', array(
+        $field = $this->getFactory()->createField('choice', 'choice', array(
             'choices' => $this->numericChoices,
         ));
 
@@ -147,7 +147,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
 
     public function testNumericChoicesByLabel()
     {
-        $field = $this->factory->createField('choice', 'choice', array(
+        $field = $this->getFactory()->createField('choice', 'choice', array(
             'label_as_value' => true,
             'choices' => $this->numericChoices,
         ));
@@ -158,7 +158,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
     // https://github.com/symfony/symfony/issues/10409
     public function testReuseNonUtf8ChoiceLists()
     {
-        $field = $this->factory->createField('choice', 'choice', array(
+        $field = $this->getFactory()->createField('choice', 'choice', array(
             'choices' => array(
                 'meter' => 'm',
                 'millimeter' => 'mm',
@@ -166,7 +166,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
             ),
         ));
 
-        $field2 = $this->factory->createField('choice', 'choice', array(
+        $field2 = $this->getFactory()->createField('choice', 'choice', array(
             'choices' => array(
                 'meter' => 'm',
                 'millimeter' => 'mm',
@@ -174,7 +174,7 @@ class ChoiceTypeTest extends FieldTypeTestCase
             ),
         ));
 
-        $field3 = $this->factory->createField('choice', 'choice', array(
+        $field3 = $this->getFactory()->createField('choice', 'choice', array(
             'choices' => array(
                 'meter' => 'm',
                 'millimeter' => 'mm',

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -19,12 +19,12 @@ class DateTimeTypeTest extends FieldTypeTestCase
 {
     public function testCreate()
     {
-        $this->factory->createField('datetime', 'datetime');
+        $this->getFactory()->createField('datetime', 'datetime');
     }
 
     public function testDifferentTimezonesDateTime()
     {
-        $field = $this->factory->createField('datetime', 'datetime', array(
+        $field = $this->getFactory()->createField('datetime', 'datetime', array(
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
         ));
@@ -37,7 +37,7 @@ class DateTimeTypeTest extends FieldTypeTestCase
 
     public function testWithSeconds()
     {
-        $field = $this->factory->createField('datetime', 'datetime', array(
+        $field = $this->getFactory()->createField('datetime', 'datetime', array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'with_seconds' => true,
@@ -49,7 +49,7 @@ class DateTimeTypeTest extends FieldTypeTestCase
 
     public function testDifferentPattern()
     {
-        $field = $this->factory->createField('datetime', 'datetime', array(
+        $field = $this->getFactory()->createField('datetime', 'datetime', array(
             'format' => "MM*yyyy*dd",
         ));
 
@@ -59,7 +59,7 @@ class DateTimeTypeTest extends FieldTypeTestCase
 
     public function testHtml5Pattern()
     {
-        $field = $this->factory->createField('datetime', 'datetime', array(
+        $field = $this->getFactory()->createField('datetime', 'datetime', array(
             'format' => DateTimeType::HTML5_FORMAT,
         ));
 
@@ -69,7 +69,7 @@ class DateTimeTypeTest extends FieldTypeTestCase
 
     public function testWrongInputFails()
     {
-        $field = $this->factory->createField('datetime', 'datetime', array(
+        $field = $this->getFactory()->createField('datetime', 'datetime', array(
             'format' => "MM-yyyy-dd",
         ));
 

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -18,12 +18,12 @@ class IntegerTypeTest extends FieldTypeTestCase
 {
     public function testCreate()
     {
-        $this->factory->createField('integer', 'integer');
+        $this->getFactory()->createField('integer', 'integer');
     }
 
     public function testCastsToInteger()
     {
-        $field = $this->factory->createField('integer', 'integer');
+        $field = $this->getFactory()->createField('integer', 'integer');
 
         $this->assertTransformedEquals($field, 1, '1.678', '1');
         $this->assertTransformedEquals($field, 1, '1', '1');
@@ -32,7 +32,7 @@ class IntegerTypeTest extends FieldTypeTestCase
 
     public function testWrongInputFails()
     {
-        $field = $this->factory->createField('integer', 'integer');
+        $field = $this->getFactory()->createField('integer', 'integer');
 
         $this->assertTransformedFails($field, 'foo');
         $this->assertTransformedFails($field, '+1');

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -28,14 +28,14 @@ class MoneyTypeTest extends FieldTypeTestCase
 
     public function testCreate()
     {
-        $this->factory->createField('money', 'money');
+        $this->getFactory()->createField('money', 'money');
     }
 
     public function testPassMoneyNL()
     {
         \Locale::setDefault('nl_NL');
 
-        $field = $this->factory->createField('money', 'money');
+        $field = $this->getFactory()->createField('money', 'money');
 
         $this->assertTransformedEquals($field, new MoneyValue('EUR', '12.00'), '€ 12,00');
         $this->assertTransformedEquals($field, new MoneyValue('EUR', '12.00'), '12,00');
@@ -45,7 +45,7 @@ class MoneyTypeTest extends FieldTypeTestCase
     {
         \Locale::setDefault('de_DE');
 
-        $field = $this->factory->createField('money', 'money');
+        $field = $this->getFactory()->createField('money', 'money');
 
         $this->assertTransformedEquals($field, new MoneyValue('EUR', '12.00'), '12,00 €');
         $this->assertTransformedEquals($field, new MoneyValue('EUR', '12.00'), '12,00');
@@ -55,7 +55,7 @@ class MoneyTypeTest extends FieldTypeTestCase
     {
         \Locale::setDefault('en_US');
 
-        $field = $this->factory->createField('money', 'money', array('default_currency' => 'JPY'));
+        $field = $this->getFactory()->createField('money', 'money', array('default_currency' => 'JPY'));
 
         $this->assertTransformedEquals($field, new MoneyValue('JPY', '12.00'), '¥12');
         $this->assertTransformedEquals($field, new MoneyValue('JPY', '12.00'), '12.00');

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -18,12 +18,12 @@ class NumberTypeTest extends FieldTypeTestCase
 {
     public function testCreate()
     {
-        $this->factory->createField('integer', 'integer');
+        $this->getFactory()->createField('integer', 'integer');
     }
 
     public function testCastsToInteger()
     {
-        $field = $this->factory->createField('number', 'number');
+        $field = $this->getFactory()->createField('number', 'number');
 
         $this->assertTransformedEquals($field, '1.678', '1,678', '1,678');
         $this->assertTransformedEquals($field, '1', '1', '1');
@@ -32,7 +32,7 @@ class NumberTypeTest extends FieldTypeTestCase
 
     public function testWrongInputFails()
     {
-        $field = $this->factory->createField('integer', 'integer');
+        $field = $this->getFactory()->createField('integer', 'integer');
 
         $this->assertTransformedFails($field, 'foo');
         $this->assertTransformedFails($field, '+1');
@@ -40,7 +40,7 @@ class NumberTypeTest extends FieldTypeTestCase
 
     public function testDefaultFormatting()
     {
-        $field = $this->factory->createField('number', 'number');
+        $field = $this->getFactory()->createField('number', 'number');
 
         $this->assertTransformedEquals($field, '12345.67890', '12345,67890', '12345,679');
         $this->assertTransformedEquals($field, '12345.679', '12345,679', '12345,679');
@@ -48,7 +48,7 @@ class NumberTypeTest extends FieldTypeTestCase
 
     public function testDefaultFormattingWithGrouping()
     {
-        $field = $this->factory->createField('number', 'number', array('grouping' => true));
+        $field = $this->getFactory()->createField('number', 'number', array('grouping' => true));
 
         $this->assertTransformedEquals($field, '12345.679', '12.345,679', '12.345,679');
         $this->assertTransformedEquals($field, '12345.679', '12345,679', '12.345,679');
@@ -56,7 +56,7 @@ class NumberTypeTest extends FieldTypeTestCase
 
     public function testDefaultFormattingWithPrecision()
     {
-        $field = $this->factory->createField('number', 'number', array('precision' => 2));
+        $field = $this->getFactory()->createField('number', 'number', array('precision' => 2));
 
         $this->assertTransformedEquals($field, '12345.68', '12345,67890', '12345,68');
         $this->assertTransformedEquals($field, '12345.67', '12345,67', '12345,67');
@@ -64,7 +64,7 @@ class NumberTypeTest extends FieldTypeTestCase
 
     public function testDefaultFormattingWithRounding()
     {
-        $field = $this->factory->createField(
+        $field = $this->getFactory()->createField(
             'number',
             'number',
             array('precision' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP)

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/TextTypeTest.php
@@ -17,7 +17,7 @@ class TextTypeTest extends FieldTypeTestCase
 {
     public function testCreate()
     {
-        $this->factory->createField('name', 'text');
+        $this->getFactory()->createField('name', 'text');
     }
 
     protected function getTestedType()

--- a/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/tests/Rollerworks/Component/Search/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -18,7 +18,7 @@ class TimeTypeTest extends FieldTypeTestCase
 {
     public function testCreate()
     {
-        $this->factory->createField('time', 'time');
+        $this->getFactory()->createField('time', 'time');
     }
 
     private $defaultTimezone;
@@ -39,7 +39,7 @@ class TimeTypeTest extends FieldTypeTestCase
 
     public function testTime()
     {
-        $field = $this->factory->createField('time', 'time');
+        $field = $this->getFactory()->createField('time', 'time');
 
         $outputTime = new \DateTime('1970-01-01 03:04:00 UTC');
 
@@ -48,7 +48,7 @@ class TimeTypeTest extends FieldTypeTestCase
 
     public function testTimeWithoutMinutes()
     {
-        $field = $this->factory->createField('time', 'time', array('with_minutes' => false));
+        $field = $this->getFactory()->createField('time', 'time', array('with_minutes' => false));
 
         $outputTime = new \DateTime('1970-01-01 03:00:00 UTC');
 
@@ -57,7 +57,7 @@ class TimeTypeTest extends FieldTypeTestCase
 
     public function testTimeWithSeconds()
     {
-        $field = $this->factory->createField('time', 'time', array('with_seconds' => true));
+        $field = $this->getFactory()->createField('time', 'time', array('with_seconds' => true));
 
         $outputTime = new \DateTime('1970-01-01 03:04:05 UTC');
 
@@ -69,7 +69,7 @@ class TimeTypeTest extends FieldTypeTestCase
      */
     public function testInitializeWithSecondsAndWithoutMinutes()
     {
-        $this->factory->createField('time', 'time', array(
+        $this->getFactory()->createField('time', 'time', array(
             'with_minutes' => false,
             'with_seconds' => true,
         ));
@@ -80,7 +80,7 @@ class TimeTypeTest extends FieldTypeTestCase
      */
     public function testThrowExceptionIfHoursIsInvalid()
     {
-        $this->factory->createField('time', 'time', array(
+        $this->getFactory()->createField('time', 'time', array(
             'hours' => 'bad value',
         ));
     }
@@ -90,7 +90,7 @@ class TimeTypeTest extends FieldTypeTestCase
      */
     public function testThrowExceptionIfMinutesIsInvalid()
     {
-        $this->factory->createField('time', 'time', array(
+        $this->getFactory()->createField('time', 'time', array(
             'minutes' => 'bad value',
         ));
     }
@@ -100,7 +100,7 @@ class TimeTypeTest extends FieldTypeTestCase
      */
     public function testThrowExceptionIfSecondsIsInvalid()
     {
-        $this->factory->createField('time', 'time', array(
+        $this->getFactory()->createField('time', 'time', array(
             'seconds' => 'bad value',
         ));
     }

--- a/tests/Rollerworks/Component/Search/Tests/Input/InputProcessorTestCase.php
+++ b/tests/Rollerworks/Component/Search/Tests/Input/InputProcessorTestCase.php
@@ -66,15 +66,15 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
      */
     protected function getFieldSet($build = true)
     {
-        $fieldSet = new FieldSetBuilder('test', $this->factory);
-        $fieldSet->add($this->factory->createField('id', 'integer')->setAcceptRange(true)->setAcceptCompares(true));
-        $fieldSet->add($this->factory->createField('name', 'text')->setAcceptPatternMatch(true));
-        $fieldSet->add($this->factory->createField('lastname', 'text'));
-        $fieldSet->add($this->factory->createField('no-range-field', 'integer')->setAcceptRange(false));
-        $fieldSet->add($this->factory->createField('no-compares-field', 'integer')->setAcceptCompares(false));
-        $fieldSet->add($this->factory->createField('no-matchers-field', 'integer')->setAcceptPatternMatch(false));
+        $fieldSet = new FieldSetBuilder('test', $this->getFactory());
+        $fieldSet->add($this->getFactory()->createField('id', 'integer')->setAcceptRange(true)->setAcceptCompares(true));
+        $fieldSet->add($this->getFactory()->createField('name', 'text')->setAcceptPatternMatch(true));
+        $fieldSet->add($this->getFactory()->createField('lastname', 'text'));
+        $fieldSet->add($this->getFactory()->createField('no-range-field', 'integer')->setAcceptRange(false));
+        $fieldSet->add($this->getFactory()->createField('no-compares-field', 'integer')->setAcceptCompares(false));
+        $fieldSet->add($this->getFactory()->createField('no-matchers-field', 'integer')->setAcceptPatternMatch(false));
         $fieldSet->add(
-            $this->factory->createField('date', 'date', array('format' => 'MM-dd-yyyy'))
+            $this->getFactory()->createField('date', 'date', array('format' => 'MM-dd-yyyy'))
               ->setAcceptRange(true)
               ->setAcceptCompares(true)
         );
@@ -628,8 +628,8 @@ abstract class InputProcessorTestCase extends SearchIntegrationTestCase
     public function it_errors_when_a_field_is_required_but_not_set($input, $fieldName, $groupIdx, $nestingLevel)
     {
         $fieldSet = $this->getFieldSet(false)
-            ->add($this->factory->createField('field1', 'text'))
-            ->add($this->factory->createField($fieldName, 'text')->setRequired(true))
+            ->add($this->getFactory()->createField('field1', 'text'))
+            ->add($this->getFactory()->createField($fieldName, 'text')->setRequired(true))
             ->getFieldSet()
         ;
 


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Bug Fix?     |no |
|New Feature? |yes|
|BC Breaks?   |yes|
|Deprecations?|no |
|Fixed Tickets|   |
|License      |MIT|

There is a BC if you used the SearchIntegrationTestCase.
Instead of using the `$factory` property you now need to call `getFactory()` after you registered all the extensions and types!