### PR TITLE
Refactor SearchConditionSerializer to use a FieldSetRegistry

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@ UPGRADE
 ## Upgrade FROM 1.0.0-beta4 to 1.0.0-beta5
 
 There has been been some major refactoring to make the system more robust
-easier to use. 
+easier to use.
 
 * The `Rollerworks\Component\Search\Formatter\TransformFormatter` is removed,
   transforming is now performed in the InputProcessor.
@@ -48,6 +48,15 @@ error-state of all nested groups.
   
 * All view-values are casted to strings now;
   When no view value is provided the "normalized" value must support casting to a string!
+  
+### SearchConditionSerializer
+
+The `SearchConditionSerializer` no longer uses the static methods
+but requires a `Rollerworks\Component\Search\FieldSetRegistryInterface` implementation
+for loading FieldSets when unserializing.
+
+**Note:** The FieldSet must be registered when serializing, this ensures the FieldSet is
+known to the system and lessens the change of breakage when unserialize.
 
 ## Upgrade from 1.0.0-beta2 to 1.0.0-beta3
 

--- a/spec/Rollerworks/Component/Search/FieldSetRegistrySpec.php
+++ b/spec/Rollerworks/Component/Search/FieldSetRegistrySpec.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace spec\Rollerworks\Component\Search;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+use Rollerworks\Component\Search\FieldSet;
+
+class FieldSetRegistrySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Rollerworks\Component\Search\FieldSetRegistry');
+    }
+
+    function it_is_a_FieldSetRegistry()
+    {
+        $this->shouldbeAnInstanceOf('Rollerworks\Component\Search\FieldSetRegistryInterface');
+    }
+
+    function it_has_no_FieldSets_when_initialized()
+    {
+        $this->all()->shouldReturn(array());
+    }
+
+    function it_supports_adding_FieldSets()
+    {
+        $fieldSet = new FieldSet('test');
+        $fieldSet->lockConfig();
+
+        $fieldSet2 = new FieldSet('test2');
+        $fieldSet2->lockConfig();
+
+        $this->add($fieldSet);
+        $this->add($fieldSet2);
+
+        $this->all()->shouldReturn(array($fieldSet->getSetName() => $fieldSet, $fieldSet2->getSetName() => $fieldSet2));
+    }
+
+    function it_can_tell_if_a_FieldSet_is_registered()
+    {
+        $fieldSet = new FieldSet('test');
+        $fieldSet->lockConfig();
+
+        $this->add($fieldSet);
+
+        $this->has('test')->shouldReturn(true);
+        $this->has('test2')->shouldReturn(false);
+    }
+
+    function it_supports_getting_a_FieldSet()
+    {
+        $fieldSet = new FieldSet('test');
+        $fieldSet->lockConfig();
+
+        $this->add($fieldSet);
+
+        $this->get('test')->shouldReturn($fieldSet);
+    }
+
+    function it_throws_when_getting_an_unregistered_FieldSet()
+    {
+        $fieldSet = new FieldSet('test');
+        $fieldSet->lockConfig();
+
+        $this->add($fieldSet);
+
+        $this->shouldThrow(
+            new InvalidArgumentException('Unable to get none registered FieldSet "test2".')
+        )->during('get', array('test2'));
+    }
+
+    function it_disallows_overwriting_a_FieldSet()
+    {
+        $fieldSet = new FieldSet('test');
+        $fieldSet->lockConfig();
+
+        $this->add($fieldSet);
+
+        $this->shouldThrow(
+            new InvalidArgumentException('Unable to overwrite already registered FieldSet "test".')
+        )->during('add', array($fieldSet));
+    }
+
+    // open meaning that the configuration is not locked
+    function it_disallows_registering_an_open_FieldSet()
+    {
+        $fieldSet = new FieldSet('test');
+
+        $this->shouldThrow(
+            new InvalidArgumentException('Unable to register none configuration-locked FieldSet "test".')
+        )->during('add', array($fieldSet));
+    }
+}

--- a/src/FieldSetRegistry.php
+++ b/src/FieldSetRegistry.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search;
+
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+
+final class FieldSetRegistry implements FieldSetRegistryInterface
+{
+    private $fieldSets = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($name)
+    {
+        return isset($this->fieldSets[$name]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($name)
+    {
+        if (isset($this->fieldSets[$name])) {
+            return $this->fieldSets[$name];
+        }
+
+        throw new InvalidArgumentException(sprintf('Unable to get none registered FieldSet "%s".', $name));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(FieldSet $fieldSet)
+    {
+        $name = $fieldSet->getSetName();
+
+        if (isset($this->fieldSets[$name])) {
+            throw new InvalidArgumentException(sprintf('Unable to overwrite already registered FieldSet "%s".', $name));
+        }
+
+        if (!$fieldSet->isConfigLocked()) {
+            throw new InvalidArgumentException(sprintf('Unable to register none configuration-locked FieldSet "%s".', $name));
+        }
+
+        $this->fieldSets[$name] = $fieldSet;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        return $this->fieldSets;
+    }
+}

--- a/src/FieldSetRegistryInterface.php
+++ b/src/FieldSetRegistryInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the RollerworksSearch Component package.
+ *
+ * (c) Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Rollerworks\Component\Search;
+
+use Rollerworks\Component\Search\Exception\InvalidArgumentException;
+
+interface FieldSetRegistryInterface
+{
+    /**
+     * Returns whether the registry has the requested FieldSet.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function has($name);
+
+    /**
+     * Get a FieldSet from the registry.
+     *
+     * @param string $name
+     *
+     * @return FieldSet
+     *
+     * @throws InvalidArgumentException when the requested FieldSet
+     *                                  is not registered
+     */
+    public function get($name);
+
+    /**
+     * Set a FieldSet on the registry.
+     *
+     * @param FieldSet $fieldSet
+     *
+     * @throws InvalidArgumentException when the FieldSet is
+     *                                  already registered
+     */
+    public function add(FieldSet $fieldSet);
+
+    /**
+     * Returns all the registered FieldSets.
+     *
+     * @return FieldSet[] as fieldSet-name => {FieldSet object}
+     */
+    public function all();
+}


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Bug Fix?     |no |
|New Feature? |yes|
|BC Breaks?   |yes|
|Deprecations?|no |
|Fixed Tickets|   |
|License      |MIT|

This PR introduces a FieldSetRegistry for tracking FieldSets throughout the search system.

The main purpose for this is to simplify the SearchConditionSerializer class
which can be now ask for a FieldSet rather then requiring this to be passed explicitly.
                   
Todo: **Update UPGRADE.md.**