### PR TITLE
move configuring of model-reference to options

### DIFF
--- a/spec/FieldSetBuilderSpec.php
+++ b/spec/FieldSetBuilderSpec.php
@@ -50,8 +50,6 @@ class FieldSetBuilderSpec extends ObjectBehavior
             'type' => 'integer',
             'options' => array(),
             'required' => false,
-            'class' => null,
-            'property' => null
         ));
     }
 
@@ -65,8 +63,6 @@ class FieldSetBuilderSpec extends ObjectBehavior
             'type' => 'integer',
             'options' => array(),
             'required' => false,
-            'class' => null,
-            'property' => null
         ));
     }
 
@@ -107,34 +103,39 @@ class FieldSetBuilderSpec extends ObjectBehavior
 
         $this->get('uid')->shouldBeLike(array(
             'type' => 'integer',
-            'options' => array('min' => 1),
+            'options' => array(
+                'min' => 1,
+                'model_class' => 'User',
+                'model_property' => 'id'
+            ),
             'required' => true,
-            'class' => 'User',
-            'property' => 'id'
         ));
 
         $this->get('username')->shouldBeLike(array(
             'type' => 'text',
-            'options' => array(),
+            'options' => array(
+                'model_class' => 'User',
+                'model_property' => 'name'
+            ),
             'required' => false,
-            'class' => 'User',
-            'property' => 'name'
         ));
 
         $this->get('gid')->shouldBeLike(array(
             'type' => 'integer',
-            'options' => array(),
+            'options' => array(
+                'model_class' => 'Group',
+                'model_property' => 'id'
+            ),
             'required' => false,
-            'class' => 'Group',
-            'property' => 'id'
         ));
 
         $this->get('group-name')->shouldBeLike(array(
             'type' => 'text',
-            'options' => array(),
+            'options' => array(
+                'model_class' => 'Group',
+                'model_property' => 'name'
+            ),
             'required' => false,
-            'class' => 'Group',
-            'property' => 'name'
         ));
     }
 
@@ -151,10 +152,26 @@ class FieldSetBuilderSpec extends ObjectBehavior
         $field2->setModelRef('Rollerworks\Component\Search\Fixtures\Entity\Group', 'name');
 
         $searchFactory->createField('id', 'integer', array('max' => 5000), true)->willReturn($field1);
-        $searchFactory->createFieldForProperty('Rollerworks\Component\Search\Fixtures\Entity\Group', 'name', 'gid', 'integer', array(), false)->willReturn($field2);
+        $searchFactory->createField(
+            'gid',
+            'integer',
+            array(
+                'model_class' => 'Rollerworks\Component\Search\Fixtures\Entity\Group',
+                'model_property' => 'name'
+            ),
+            false
+        )->willReturn($field2);
 
         $this->add('id', 'integer', array('max' => 5000), true);
-        $this->add('gid', 'integer', array(), false, 'Rollerworks\Component\Search\Fixtures\Entity\Group', 'name');
+        $this->add(
+            'gid',
+            'integer',
+            array(
+                'model_class' => 'Rollerworks\Component\Search\Fixtures\Entity\Group',
+                'model_property' => 'name'
+            ),
+            false
+        );
 
         $expectedFieldSet = new FieldSet('test');
 
@@ -182,10 +199,26 @@ class FieldSetBuilderSpec extends ObjectBehavior
         $field2->setModelRef('Rollerworks\Component\Search\Fixtures\Entity\Group', 'name');
 
         $searchFactory->createField('id', 'integer', array('max' => 5000), true)->willReturn($field1);
-        $searchFactory->createFieldForProperty('Rollerworks\Component\Search\Fixtures\Entity\Group', 'name', 'gid', 'integer', array(), false)->willReturn($field2);
+        $searchFactory->createField(
+            'gid',
+            'integer',
+            array(
+                'model_class' => 'Rollerworks\Component\Search\Fixtures\Entity\Group',
+                'model_property' => 'name'
+            ),
+            false
+        )->willReturn($field2);
 
         $this->add('id', 'integer', array('max' => 5000), true);
-        $this->add('gid', 'integer', array(), false, 'Rollerworks\Component\Search\Fixtures\Entity\Group', 'name');
+        $this->add(
+            'gid',
+            'integer',
+            array(
+                'model_class' => 'Rollerworks\Component\Search\Fixtures\Entity\Group',
+                'model_property' => 'name'
+            ),
+            false
+        );
 
         $this->getFieldSet();
 

--- a/spec/SearchFactorySpec.php
+++ b/spec/SearchFactorySpec.php
@@ -65,15 +65,39 @@ class SearchFactorySpec extends ObjectBehavior
     {
         $this->beConstructedWith($registry->getWrappedObject(), $resolvedTypeFactory->getWrappedObject());
 
-        $expectedField = new SearchField('uid', $type->getWrappedObject());
+        $expectedField = new SearchField(
+            'uid', $type->getWrappedObject(), array(
+            'model_class' => 'Entity\User',
+            'model_property' => 'id'
+        )
+        );
         $expectedField->setModelRef('Entity\User', 'id');
 
         $type->getName()->willReturn('number');
-        $type->createField('uid', array())->willReturn($expectedField);
+        $type->createField(
+            'uid',
+            array(
+                'model_class' => 'Entity\User',
+                'model_property' => 'id'
+            )
+        )->willReturn($expectedField);
 
         $registry->getType('number')->willReturn($type->getWrappedObject());
-        $type->buildType(Argument::exact($expectedField), array())->shouldBeCalled();
+        $type->buildType(
+            Argument::exact($expectedField),
+            array(
+                'model_class' => 'Entity\User',
+                'model_property' => 'id'
+            )
+        )->shouldBeCalled();
 
-        $this->createFieldForProperty('Entity\User', 'id', 'uid', 'number')->shouldEqual($expectedField);
+        $this->createField(
+            'uid',
+            'number',
+            array(
+                'model_class' => 'Entity\User',
+                'model_property' => 'id'
+            )
+        )->shouldEqual($expectedField);
     }
 }

--- a/src/Extension/Core/Type/FieldType.php
+++ b/src/Extension/Core/Type/FieldType.php
@@ -69,6 +69,8 @@ class FieldType extends AbstractFieldType
             array(
                 'invalid_message' => 'This value is not valid.',
                 'invalid_message_parameters' => array(),
+                'model_class' => null,
+                'model_property' => null,
             )
         );
 

--- a/src/SearchFactory.php
+++ b/src/SearchFactory.php
@@ -77,6 +77,10 @@ class SearchFactory implements SearchFactoryInterface
      * @param bool   $required
      *
      * @return SearchField
+     *
+     * @deprecated Deprecated since version 1.0.0-beta5, to be removed in 2.0.
+     *             Use createField() with the 'model_class' and 'model_property'
+     *             options instead.
      */
     public function createFieldForProperty($class, $property, $name, $type, array $options = array(), $required = false)
     {

--- a/src/SearchFactoryInterface.php
+++ b/src/SearchFactoryInterface.php
@@ -29,20 +29,6 @@ interface SearchFactoryInterface
     public function createField($name, $type, array $options = array(), $required = false);
 
     /**
-     * Create a new search field referenced by property.
-     *
-     * @param string $class
-     * @param string $property
-     * @param string $name
-     * @param string $type
-     * @param array  $options
-     * @param bool   $required
-     *
-     * @return FieldConfigInterface
-     */
-    public function createFieldForProperty($class, $property, $name, $type, array $options = array(), $required = false);
-
-    /**
      * Create a new FieldsetBuilderInterface instance.
      *
      * @param string $name

--- a/src/SearchField.php
+++ b/src/SearchField.php
@@ -55,16 +55,6 @@ class SearchField implements FieldConfigInterface
     private $valueComparison;
 
     /**
-     * @var string
-     */
-    private $modelRefClass;
-
-    /**
-     * @var string
-     */
-    private $modelRefField;
-
-    /**
      * @var bool
      */
     private $locked = false;
@@ -200,6 +190,9 @@ class SearchField implements FieldConfigInterface
      * @param string $property
      *
      * @throws BadMethodCallException when the data is locked
+     *
+     * @deprecated Deprecated since version 1.0.0-beta5, to be removed in 2.0.
+     *             Use the 'model_class' and 'model_property' options instead.
      */
     public function setModelRef($class, $property)
     {
@@ -209,8 +202,8 @@ class SearchField implements FieldConfigInterface
             );
         }
 
-        $this->modelRefClass = $class;
-        $this->modelRefField = $property;
+        $this->options['model_class'] = $class;
+        $this->options['model_property'] = $property;
 
         return $this;
     }
@@ -220,11 +213,11 @@ class SearchField implements FieldConfigInterface
      *
      * This is required for certain storage engines.
      *
-     * @return string
+     * @return string|null
      */
     public function getModelRefClass()
     {
-        return $this->modelRefClass;
+        return $this->getOption('model_class');
     }
 
     /**
@@ -232,11 +225,11 @@ class SearchField implements FieldConfigInterface
      *
      * This is required for certain storage engines.
      *
-     * @return string
+     * @return string|null
      */
     public function getModelRefProperty()
     {
-        return $this->modelRefField;
+        return $this->getOption('model_property');
     }
 
     /**


### PR DESCRIPTION
                   
|Q            |A  |
|---          |---|
|Bug Fix?     |no |
|New Feature? |yes|
|BC Breaks?   |no |
|Deprecations?|no |
|Fixed Tickets|   |
|License      |MIT|
                   
This moves the configuring of field's model-reference to the options. The model reference is not actually mandatory but was introduced for Doctrine ORM and Metadata loading.

But currently they can't be used for options as the configureOptions method doesn't receive the FieldConfig and so (lazy) options that depend on this information are impossible as I want to do in: 
https://github.com/rollerworks/rollerworks-search-symfony-validator/issues/5